### PR TITLE
Fix: Cleanup and Load

### DIFF
--- a/src/leptos_component.rs
+++ b/src/leptos_component.rs
@@ -1,11 +1,23 @@
 use bevy::prelude::*;
 use leptos::prelude::*;
+use leptos_use::use_raf_fn;
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+type StartAppFn = Rc<RefCell<Option<Box<dyn FnOnce()>>>>;
+type PauseFn = Rc<RefCell<Option<Box<dyn Fn()>>>>;
 
 use crate::{
     messages::{message_l2b, LeptosChannelMessageSender},
     plugin::{LeptosBevyCanvasCleanup, LeptosBevyCanvasPlugin},
     prelude::LeptosBevyApp,
 };
+
+/// Set when a BevyCanvas is destroyed. Cleared by the Bevy cleanup system
+/// after it sends `AppExit`, allowing the next mount's polling loop to proceed.
+pub(crate) static AWAITING_CLEANUP: AtomicBool = AtomicBool::new(false);
 
 /// Embeds a Bevy app in a Leptos component. It will add an HTML canvas element and start
 /// running the Bevy app inside it.
@@ -19,14 +31,45 @@ pub fn BevyCanvas(
 ) -> impl IntoView {
     let (shutdown_canvas, set_shutdown_canvas) = message_l2b::<LeptosBevyCanvasCleanup>();
 
-    request_animation_frame(move || {
+    let start_app: StartAppFn = Rc::new(RefCell::new(Some(Box::new(move || {
         let mut app = init();
         app.add_plugins(LeptosBevyCanvasPlugin)
             .import_message_from_leptos(set_shutdown_canvas);
         app.run();
+    }))));
+
+    let pause_polling: PauseFn = Rc::new(RefCell::new(None));
+    let app_started = Arc::new(AtomicBool::new(false));
+
+    // Poll each frame until winit's event-loop cleanup is done, then start.
+    let raf = use_raf_fn({
+        let start_app = start_app.clone();
+        let pause_polling = pause_polling.clone();
+        let app_started = app_started.clone();
+        move |_| {
+            if !AWAITING_CLEANUP.load(Ordering::Relaxed) {
+                if let Some(start) = start_app.borrow_mut().take() {
+                    app_started.store(true, Ordering::Relaxed);
+                    request_animation_frame(start);
+                    // Stop polling now that the app is running.
+                    if let Some(pause) = pause_polling.borrow_mut().take() {
+                        pause();
+                    }
+                }
+            }
+        }
     });
 
+    // Make the pause handle available to the polling callback.
+    *pause_polling.borrow_mut() = Some(Box::new(raf.pause.clone()));
+
     on_cleanup(move || {
+        (raf.pause)();
+        if !app_started.load(Ordering::Relaxed) {
+            // App never started, no CleanupFlag exists to clear this.
+            return;
+        }
+        AWAITING_CLEANUP.store(true, Ordering::Relaxed);
         shutdown_canvas
             .send(LeptosBevyCanvasCleanup)
             .expect("couldn't send cleanup to bevy app");

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,8 +1,22 @@
 use bevy::prelude::*;
 
+use crate::leptos_component::AWAITING_CLEANUP;
+use std::sync::atomic::Ordering;
+
+/// Clears the cleanup flag when Bevy's World is dropped during shutdown.
+#[derive(Resource)]
+struct CleanupFlag;
+
+impl Drop for CleanupFlag {
+    fn drop(&mut self) {
+        AWAITING_CLEANUP.store(false, Ordering::Relaxed);
+    }
+}
+
 pub struct LeptosBevyCanvasPlugin;
 impl Plugin for LeptosBevyCanvasPlugin {
     fn build(&self, app: &mut App) {
+        app.insert_resource(CleanupFlag);
         app.add_message::<LeptosBevyCanvasCleanup>();
         app.add_systems(First, cleanup);
     }


### PR DESCRIPTION
# Fix: Cleanup and Load

This PR fixes the error I had when destroying one component and creating another when both had different BevyCanvas.

## Fix remount race condition with winit event loop cleanup

When a `BevyCanvas` component is unmounted and quickly re-mounted (e.g. via Leptos routing or conditional rendering), the new Bevy app could attempt to start while the previous winit event loop was still shutting down. This caused a panic because winit does not support multiple concurrent event loops.

### Changes

- **`src/leptos_component.rs`**: Wrap the existing `request_animation_frame` startup in a `use_raf_fn` polling loop that waits for the previous app to fully shut down before proceeding. Add an `AWAITING_CLEANUP` static `AtomicBool` flag that gates new app startup.
- **`src/plugin.rs`**: Add a `CleanupFlag` resource with a `Drop` impl that clears `AWAITING_CLEANUP` when Bevy's `World` is dropped during shutdown.

### How it works

1. On first mount, the `use_raf_fn` polling loop sees `AWAITING_CLEANUP == false`, starts the Bevy app via `request_animation_frame`, and pauses itself.
2. On unmount, `on_cleanup` pauses the polling loop (in case it's still waiting), sets `AWAITING_CLEANUP = true`, and sends the existing `LeptosBevyCanvasCleanup` shutdown message to Bevy.
3. Bevy processes `AppExit`, drops its `World`, which drops `CleanupFlag`, which clears the flag.
4. The newly mounted component's polling loop sees the flag is clear and starts the app via `request_animation_frame`.

If the component is unmounted before the app ever started (e.g. rapid mount/unmount), the `on_cleanup` handler detects this via `app_started` and returns early without setting the flag, since no `CleanupFlag` resource exists to clear it.

### No breaking changes

The public API (types, signatures, re-exports) is unchanged. All new items (`AWAITING_CLEANUP`, `CleanupFlag`, type aliases) are crate-private.

**Behavioral change:** App startup is delayed by one additional animation frame compared to before. Previously `request_animation_frame` was called directly on mount; now `use_raf_fn` polls first, then calls `request_animation_frame`, adding one frame of latency.

### Notes

- `Ordering::Relaxed` is sufficient since this runs single-threaded in WASM.
- Assumes a single `BevyCanvas` instance at a time (consistent with existing design).