### PR TITLE
Fix state transifix: use NextState for state synchronization to trigger transitionstion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,30 +1,29 @@
 [package]
-name = "leptos-bevy-canvas"
-version = "0.5.1"
-edition = "2021"
 categories = ["gui", "web-programming", "rendering", "graphics", "wasm"]
 description = "Embed an idiomatic Bevy app inside your Leptos app with ease."
+edition = "2021"
 exclude = ["examples/", "tests/"]
 keywords = ["leptos", "bevy", "graphics", "wasm", "canvas"]
 license = "MIT OR Apache-2.0"
+name = "leptos-bevy-canvas"
 readme = "README.md"
 repository = "https://github.com/Synphonyte/leptos-bevy-canvas"
+version = "0.5.1"
 
 [dependencies]
-bevy = { version = "0.18", default-features = false }
+bevy = {version = "0.18", default-features = false}
 crossbeam-channel = "0.5"
 leptos = "0.8"
-leptos-use = { version = "0.18", default-features = false, features = [
+leptos-use = {version = "0.18", default-features = false, features = [
   "use_raf_fn",
-] }
+]}
 paste = "1.0.15"
 variadics_please = "1.1.0"
 
 [dev-dependencies]
-bevy = { version = "0.18", default-features = false, features = [
+bevy = {version = "0.18", default-features = false, features = [
   "bevy_window",
-  "bevy_state",
-] }
+]}
 
 [features]
 bevy_state = ["bevy/bevy_state"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ variadics_please = "1.1.0"
 [dev-dependencies]
 bevy = { version = "0.18", default-features = false, features = [
   "bevy_window",
+  "bevy_state",
 ] }
 
 [features]

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -81,8 +81,11 @@ where
 
 /// Takes care of synchronizing a state between Bevy and a Leptos signal
 #[cfg(feature = "bevy_state")]
-pub fn sync_signal_state<D, S>(mut state: ResMut<State<S>>, sync: Res<D>)
-where
+pub fn sync_signal_state<D, S>(
+    mut state: ResMut<State<S>>,
+    sync: Res<D>,
+    mut next_state: ResMut<NextState<S>>,
+) where
     S: bevy::state::state::FreelyMutableState + Clone,
     D: HasReceiver<S> + HasSender<S> + Resource,
 {
@@ -91,7 +94,8 @@ where
     }
 
     for event in sync.rx().try_iter() {
-        *state = State::new(event);
+        // *state = State::new(event);
+        next_state.set(event);
     }
 }
 

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -82,9 +82,9 @@ where
 /// Takes care of synchronizing a state between Bevy and a Leptos signal
 #[cfg(feature = "bevy_state")]
 pub fn sync_signal_state<D, S>(
-    mut state: ResMut<State<S>>,
-    sync: Res<D>,
+    state: ResMut<State<S>>,
     mut next_state: ResMut<NextState<S>>,
+    sync: Res<D>,
 ) where
     S: bevy::state::state::FreelyMutableState + Clone,
     D: HasReceiver<S> + HasSender<S> + Resource,
@@ -92,13 +92,10 @@ pub fn sync_signal_state<D, S>(
     if state.is_changed() && !state.is_added() {
         sync.tx().send(state.clone()).unwrap();
     }
-
     for event in sync.rx().try_iter() {
-        // *state = State::new(event);
         next_state.set(event);
     }
 }
-
 /// Synchronizes a Bevy query's `.get_single_mut()` with a Leptos signal.
 pub fn sync_query<D, F>(
     duplex: Res<BevyMessageDuplex<Option<D>>>,


### PR DESCRIPTION
### Description
Currently, `sync_signal_state` updates Bevy's state by directly modifying `ResMut<State<S>>`. This bypasses Bevy's standard state transition logic, meaning `OnEnter`, `OnExit`, and other transition-based systems are never triggered when the state is changed from the Leptos side.

This PR introduces `ResMut<NextState<S>>` into the `sync_signal_state` system to ensure that state changes from Leptos follow Bevy's formal transition schedule.

### Changes
- Added `ResMut<NextState<S>>` to `sync_signal_state` system.
- Changed state update logic from `*state = State::new(event)` to `next_state.set(event)`.
- Updated `sync_leptos_signal_with_state` to reflect the system signature change.

### Verification
Verified locally with a Leptos + Bevy 2D project. `OnEnter` and `OnExit` systems now trigger correctly when clicking buttons in the Leptos UI.